### PR TITLE
No more need for poetry to configure a pypi token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,6 @@ jobs:
       - uses: ./.github/actions/python-poetry-env
       - name: Publish to pypi
         run: |
-          poetry config pypi-token.pypi ${{ secrets.PYPI_TOKEN }}
           poetry publish --build --no-interaction
       - name: Deploy docs
         run: poetry run mkdocs gh-deploy --force


### PR DESCRIPTION
## Description

First attempt at using pypi trusted publishing. See #1 