### PR TITLE
Build with poetry, publish with pypa action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,11 +7,18 @@ on:
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write
+      contents: read
+
     steps:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/python-poetry-env
-      - name: Publish to pypi
+      - name: Build
         run: |
-          poetry publish --build --no-interaction
+          poetry build --no-interaction
+      - name: Publish to Pypi
+        uses: pypa/gh-action-pypi-publish@release/v1
       - name: Deploy docs
         run: poetry run mkdocs gh-deploy --force


### PR DESCRIPTION
Poetry doesn't have native support for trusted publishing. See discussion in https://github.com/python-poetry/poetry/issues/7940

There are two possible solutions:
* Mint a token with [tschm/token-mint-action](https://github.com/tschm/token-mint-action)
* Have poetry only do the build and publish with [pypa/gh-action-pypi-publish](https://github.com/pypa/gh-action-pypi-publish)